### PR TITLE
Fixed warnings in nuget workflow

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -27,10 +27,10 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
      

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -22,7 +22,7 @@ on:
               required: true
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: Update NuGet package
     steps:
 


### PR DESCRIPTION
Bumped the environment the jobs runs on from ubuntu-18.04 to ubuntu-latest witch in this point in time points to 20.04.

I also bumped actions/checkout and actions/setup-dotnet to the latest version v3